### PR TITLE
fix: use default zh-hans

### DIFF
--- a/zh/book.json
+++ b/zh/book.json
@@ -1,0 +1,3 @@
+{
+    "language": "zh-hans"
+}


### PR DESCRIPTION
`zh` === `zh-tw`

![image](https://user-images.githubusercontent.com/2230882/65829459-5d70d600-e2d8-11e9-88e5-9325e090cba4.png)
